### PR TITLE
Settings textures compress

### DIFF
--- a/UnityGLTF/Assets/UnityGLTF/Editor/Scripts/GLTFExportMenu.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Editor/Scripts/GLTFExportMenu.cs
@@ -32,7 +32,7 @@ public class GLTFExportMenu : EditorWindow
     }
 
     [MenuItem("GLTF/Export Selected")]
-	static void ExportSelected()
+	public static void ExportSelected()
 	{
 		string name;
 		if (Selection.transforms.Length > 1)

--- a/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/GLTFSceneExporter_CompressedTextures.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/GLTFSceneExporter_CompressedTextures.cs
@@ -1,0 +1,147 @@
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using GLTF.Schema;
+using UnityEditor;
+using UnityEngine;
+using WrapMode = GLTF.Schema.WrapMode;
+
+namespace UnityGLTF
+{
+
+  public partial class GLTFSceneExporter
+  {
+
+
+    public static TextureFormat Compressed_GetSourceFormat(TextureFormat targetFormat)
+    {
+
+      switch (targetFormat)
+      {
+        case TextureFormat.RGB24:
+        case TextureFormat.DXT1:
+        case TextureFormat.PVRTC_RGB2:
+        case TextureFormat.PVRTC_RGB4:
+        case TextureFormat.ETC_RGB4:
+          return TextureFormat.RGB24;
+        default:
+          return TextureFormat.RGBA32;
+      }
+
+    }
+
+    // BOOUUH !! Todo check if there is a better way to handle this
+    public static void FlipTextureVertically(Texture2D original)
+    {
+      var originalPixels = original.GetPixels();
+
+      Color[] newPixels = new Color[originalPixels.Length];
+
+      int width = original.width;
+      int rows = original.height;
+
+      for (int x = 0; x < width; x++)
+      {
+        for (int y = 0; y < rows; y++)
+        {
+          newPixels[x + y * width] = originalPixels[x + (rows - y - 1) * width];
+        }
+      }
+
+      original.SetPixels(newPixels);
+      original.Apply();
+    }
+
+
+    public void ExportCompressed(Texture2D source, Texture2D texture, string outputPath)
+    {
+
+      GLTFTexturesRegistry reg = GLTFExportSettings.Defaults.info.TexturesRegistry;
+
+      GLTFExportTextureSettings setting = reg.GetSettings(source);
+      if (setting == null){
+        setting = GLTFExportSettings.Defaults.info.TextureSettingsDefaults;
+      }
+
+      if (!setting.Compress)
+        return;
+
+
+      // ==========
+      // FORMATS
+      // TODO: update with alpha or configurable maybe
+      // ==========
+      List<TextureFormat> compressFormats = new List<TextureFormat>();
+      compressFormats.Add(TextureFormat.PVRTC_RGB4);
+      compressFormats.Add(TextureFormat.DXT1);
+      compressFormats.Add(TextureFormat.ETC_RGB4);
+
+
+      EditorUtility.DisplayProgressBar("Texture Compress", "Compressing textures", 0.0f);
+      float startTime = (float)EditorApplication.timeSinceStartup;
+
+
+      int clen = compressFormats.Count;
+      int idx = 0;
+
+      foreach (TextureFormat targetFormat in compressFormats)
+      {
+
+        EditorUtility.DisplayProgressBar(
+          "Texture Compress (" + Mathf.Floor((float)(EditorApplication.timeSinceStartup - startTime)) + "s)",
+          "Compressing texture " + texture.name + " ... ", (float)clen / (float)idx
+        );
+        idx++;
+
+        var destRenderTexture = RenderTexture.GetTemporary(texture.width, texture.height, 0, RenderTextureFormat.ARGB32, RenderTextureReadWrite.Linear);
+        Graphics.Blit(texture, destRenderTexture);
+
+        TextureFormat tgt = targetFormat;
+        TextureFormat fmt = Compressed_GetSourceFormat(tgt);
+        bool mip = setting.GenerateMipMap;
+
+        Texture2D exportTexture = new Texture2D(texture.width, texture.height, fmt, mip);
+
+        exportTexture.ReadPixels(new Rect(0, 0, destRenderTexture.width, destRenderTexture.height), 0, 0);
+        FlipTextureVertically(exportTexture);
+        EditorUtility.CompressTexture(exportTexture, tgt, TextureCompressionQuality.Best);
+        exportTexture.Apply();
+
+        try
+        {
+
+          // Write data
+          byte[] data = KTX.Encode(exportTexture, exportTexture.format);
+          var filePath = ConstructImageFilenamePath(source, outputPath);
+          string p = filePath + KTX.GetExt(targetFormat);
+          File.WriteAllBytes(p, data);
+
+        }
+        catch (Exception e)
+        {
+          EditorUtility.ClearProgressBar();
+          throw e;
+        }
+
+
+        RenderTexture.ReleaseTemporary(destRenderTexture);
+
+        if (Application.isEditor)
+        {
+          GameObject.DestroyImmediate(exportTexture);
+        }
+        else
+        {
+          GameObject.Destroy(exportTexture);
+        }
+
+      }
+
+      EditorUtility.ClearProgressBar();
+
+    }
+
+  }
+
+}

--- a/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/GLTFSceneExporter_Textures.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/GLTFSceneExporter_Textures.cs
@@ -2,397 +2,443 @@
 using System;
 using System.IO;
 using GLTF.Schema;
+using Newtonsoft.Json.Linq;
 using UnityEngine;
 using WrapMode = GLTF.Schema.WrapMode;
 
 namespace UnityGLTF
 {
-	
-	public partial class GLTFSceneExporter
-	{
-
-
-		private enum IMAGETYPE
-		{
-			RGB,
-			RGBA,
-			R,
-			G,
-			B,
-			A,
-			G_INVERT
-		}
-
-		private enum TextureMapType
-		{
-			Main,
-			Bump,
-			SpecGloss,
-			Emission,
-			MetallicGloss,
-			Light,
-			Occlusion
-		}
-
-		private struct ImageInfo
-		{
-			public Texture2D texture;
-			public TextureMapType textureMapType;
-		}
-
-
-		private void ExportImages(string outputPath)
-		{
-			for (int t = 0; t < _imageInfos.Count; ++t)
-			{
-				var image = _imageInfos[t].texture;
-				int height = image.height;
-				int width = image.width;
-
-				switch (_imageInfos[t].textureMapType)
-				{
-					case TextureMapType.MetallicGloss:
-						ExportMetallicGlossTexture(image, outputPath);
-						break;
-					case TextureMapType.Bump:
-						ExportNormalTexture(image, outputPath);
-						break;
-					default:
-						ExportTexture(image, outputPath);
-						break;
-				}
-			}
-		}
-
-		/// <summary>
-		/// This converts Unity's metallic-gloss texture representation into GLTF's metallic-roughness specifications.
-		/// Unity's metallic-gloss A channel (glossiness) is inverted and goes into GLTF's metallic-roughness G channel (roughness).
-		/// Unity's metallic-gloss R channel (metallic) goes into GLTF's metallic-roughess B channel.
-		/// </summary>
-		/// <param name="texture">Unity's metallic-gloss texture to be exported</param>
-		/// <param name="outputPath">The location to export the texture</param>
-		private void ExportMetallicGlossTexture(Texture2D texture, string outputPath)
-		{
-			var destRenderTexture = RenderTexture.GetTemporary(texture.width, texture.height, 0, RenderTextureFormat.ARGB32, RenderTextureReadWrite.Linear);
-
-			Graphics.Blit(texture, destRenderTexture, _metalGlossChannelSwapMaterial);
-
-			var exportTexture = new Texture2D(texture.width, texture.height);
-			exportTexture.ReadPixels(new Rect(0, 0, destRenderTexture.width, destRenderTexture.height), 0, 0);
-			exportTexture.Apply();
-
-			var finalFilenamePath = ConstructImageFilenamePath(texture, outputPath);
-			File.WriteAllBytes(finalFilenamePath, exportTexture.EncodeToPNG());
-
-			RenderTexture.ReleaseTemporary(destRenderTexture);
-			if (Application.isEditor)
-			{
-				GameObject.DestroyImmediate(exportTexture);
-			}
-			else
-			{
-				GameObject.Destroy(exportTexture);
-			}
-		}
-
-		/// <summary>
-		/// This export's the normal texture. If a texture is marked as a normal map, the values are stored in the A and G channel.
-		/// To output the correct normal texture, the A channel is put into the R channel.
-		/// </summary>
-		/// <param name="texture">Unity's normal texture to be exported</param>
-		/// <param name="outputPath">The location to export the texture</param>
-		private void ExportNormalTexture(Texture2D texture, string outputPath)
-		{
-			var destRenderTexture = RenderTexture.GetTemporary(texture.width, texture.height, 0, RenderTextureFormat.ARGB32, RenderTextureReadWrite.Linear);
-
-			Graphics.Blit(texture, destRenderTexture, _normalChannelMaterial);
-
-			var exportTexture = new Texture2D(texture.width, texture.height);
-			exportTexture.ReadPixels(new Rect(0, 0, destRenderTexture.width, destRenderTexture.height), 0, 0);
-			exportTexture.Apply();
-
-			var finalFilenamePath = ConstructImageFilenamePath(texture, outputPath);
-			File.WriteAllBytes(finalFilenamePath, exportTexture.EncodeToPNG());
-
-			RenderTexture.ReleaseTemporary(destRenderTexture);
-			if (Application.isEditor)
-			{
-				GameObject.DestroyImmediate(exportTexture);
-			}
-			else
-			{
-				GameObject.Destroy(exportTexture);
-			}
-		}
-
-		private void ExportTexture(Texture2D texture, string outputPath)
-		{
-			var destRenderTexture = RenderTexture.GetTemporary(texture.width, texture.height, 0, RenderTextureFormat.ARGB32, RenderTextureReadWrite.sRGB);
-
-			Graphics.Blit(texture, destRenderTexture);
-
-			var exportTexture = new Texture2D(texture.width, texture.height);
-			exportTexture.ReadPixels(new Rect(0, 0, destRenderTexture.width, destRenderTexture.height), 0, 0);
-			exportTexture.Apply();
-
-			var finalFilenamePath = ConstructImageFilenamePath(texture, outputPath);
-			File.WriteAllBytes(finalFilenamePath, exportTexture.EncodeToPNG());
-
-			RenderTexture.ReleaseTemporary(destRenderTexture);
-			if (Application.isEditor)
-			{
-				GameObject.DestroyImmediate(exportTexture);
-			}
-			else
-			{
-				GameObject.Destroy(exportTexture);
-			}
-		}
-
-		private string ConstructImageFilenamePath(Texture2D texture, string outputPath)
-		{
-			var imagePath = _exportOptions.TexturePathRetriever(texture);
-			if (string.IsNullOrEmpty(imagePath))
-			{
-				imagePath = Path.Combine(outputPath, texture.name);
-			}
-
-			var filenamePath = Path.Combine(outputPath, imagePath);
-			if (!ExportFullPath)
-			{
-				filenamePath = outputPath + "/" + texture.name;
-			}
-			var file = new FileInfo(filenamePath);
-			file.Directory.Create();
-			return Path.ChangeExtension(filenamePath, ".png");
-		}
-
-
-		private TextureInfo ExportTextureInfo(Texture texture, TextureMapType textureMapType)
-		{
-			var info = new TextureInfo();
-
-			info.Index = ExportTexture(texture, textureMapType);
-
-			return info;
-		}
-
-		private TextureId ExportTexture(Texture textureObj, TextureMapType textureMapType)
-		{
-			TextureId id = GetTextureId(_root, textureObj);
-			if (id != null)
-			{
-				return id;
-			}
-
-			var texture = new GLTFTexture();
-
-			//If texture name not set give it a unique name using count
-			if (textureObj.name == "")
-			{
-				textureObj.name = (_root.Textures.Count + 1).ToString();
-			}
-
-			if (ExportNames)
-			{
-				texture.Name = textureObj.name;
-			}
-
-			if (_shouldUseInternalBufferForImages)
-			{
-				texture.Source = ExportImageInternalBuffer(textureObj, textureMapType);
-			}
-			else
-			{
-				texture.Source = ExportImage(textureObj, textureMapType);
-			}
-
-			texture.Sampler = ExportSampler(textureObj);
-
-			_textures.Add(textureObj);
-
-			id = new TextureId
-			{
-				Id = _root.Textures.Count,
-				Root = _root
-			};
-
-			_root.Textures.Add(texture);
-
-			return id;
-		}
-
-		private ImageId ExportImage(Texture texture, TextureMapType texturMapType)
-		{
-			ImageId id = GetImageId(_root, texture);
-			if (id != null)
-			{
-				return id;
-			}
-
-			var image = new GLTFImage();
-
-			if (ExportNames)
-			{
-				image.Name = texture.name;
-			}
-
-			_imageInfos.Add(new ImageInfo
-			{
-				texture = texture as Texture2D,
-				textureMapType = texturMapType
-			});
-
-			var imagePath = _exportOptions.TexturePathRetriever(texture);
-			if (string.IsNullOrEmpty(imagePath))
-			{
-				imagePath = texture.name;
-			}
-
-			var filenamePath = Path.ChangeExtension(imagePath, ".png");
-			if (!ExportFullPath)
-			{
-				filenamePath = Path.ChangeExtension(texture.name, ".png");
-			}
-			image.Uri = Uri.EscapeUriString(filenamePath);
-
-			id = new ImageId
-			{
-				Id = _root.Images.Count,
-				Root = _root
-			};
-
-			_root.Images.Add(image);
-
-			return id;
-		}
-
-		private ImageId ExportImageInternalBuffer(UnityEngine.Texture texture, TextureMapType texturMapType)
-		{
-
-		    if (texture == null)
-		    {
-			throw new Exception("texture can not be NULL.");
-		    }
-
-		    var image = new GLTFImage();
-		    image.MimeType = "image/png";
-
-		    var byteOffset = _bufferWriter.BaseStream.Position;
-
-		    {//
-			var destRenderTexture = RenderTexture.GetTemporary(texture.width, texture.height, 24, RenderTextureFormat.ARGB32, RenderTextureReadWrite.sRGB);
-			GL.sRGBWrite = true;
-			switch (texturMapType)
-			{
-			    case TextureMapType.MetallicGloss:
-				Graphics.Blit(texture, destRenderTexture, _metalGlossChannelSwapMaterial);
-				break;
-			    case TextureMapType.Bump:
-				Graphics.Blit(texture, destRenderTexture, _normalChannelMaterial);
-				break;
-			    default:
-				Graphics.Blit(texture, destRenderTexture);
-				break;
-			}
-
-			var exportTexture = new Texture2D(texture.width, texture.height, TextureFormat.ARGB32, false);
-			exportTexture.ReadPixels(new Rect(0, 0, destRenderTexture.width, destRenderTexture.height), 0, 0);
-			exportTexture.Apply();
-
-			var pngImageData = exportTexture.EncodeToPNG();
-			_bufferWriter.Write(pngImageData);
-
-			RenderTexture.ReleaseTemporary(destRenderTexture);
-
-			GL.sRGBWrite = false;
-			if (Application.isEditor)
-			{
-			    UnityEngine.Object.DestroyImmediate(exportTexture);
-			}
-			else
-			{
-			    UnityEngine.Object.Destroy(exportTexture);
-			}
-		    }
-
-		    var byteLength = _bufferWriter.BaseStream.Position - byteOffset;
-
-		    byteLength = AppendToBufferMultiplyOf4(byteOffset, byteLength);
-
-		    image.BufferView = ExportBufferView((uint)byteOffset, (uint)byteLength);
-
-
-		    var id = new ImageId
-		    {
-			Id = _root.Images.Count,
-			Root = _root
-		    };
-		    _root.Images.Add(image);
-
-		    return id;
-		}
-		private SamplerId ExportSampler(Texture texture)
-		{
-			var samplerId = GetSamplerId(_root, texture);
-			if (samplerId != null)
-				return samplerId;
-
-			var sampler = new Sampler();
-
-			switch (texture.wrapMode)
-			{
-				case TextureWrapMode.Clamp:
-					sampler.WrapS = WrapMode.ClampToEdge;
-					sampler.WrapT = WrapMode.ClampToEdge;
-					break;
-				case TextureWrapMode.Repeat:
-					sampler.WrapS = WrapMode.Repeat;
-					sampler.WrapT = WrapMode.Repeat;
-					break;
-				case TextureWrapMode.Mirror:
-					sampler.WrapS = WrapMode.MirroredRepeat;
-					sampler.WrapT = WrapMode.MirroredRepeat;
-					break;
-				default:
-					Debug.LogWarning("Unsupported Texture.wrapMode: " + texture.wrapMode);
-					sampler.WrapS = WrapMode.Repeat;
-					sampler.WrapT = WrapMode.Repeat;
-					break;
-			}
-
-			switch (texture.filterMode)
-			{
-				case FilterMode.Point:
-					sampler.MinFilter = MinFilterMode.NearestMipmapNearest;
-					sampler.MagFilter = MagFilterMode.Nearest;
-					break;
-				case FilterMode.Bilinear:
-					sampler.MinFilter = MinFilterMode.LinearMipmapNearest;
-					sampler.MagFilter = MagFilterMode.Linear;
-					break;
-				case FilterMode.Trilinear:
-					sampler.MinFilter = MinFilterMode.LinearMipmapLinear;
-					sampler.MagFilter = MagFilterMode.Linear;
-					break;
-				default:
-					Debug.LogWarning("Unsupported Texture.filterMode: " + texture.filterMode);
-					sampler.MinFilter = MinFilterMode.LinearMipmapLinear;
-					sampler.MagFilter = MagFilterMode.Linear;
-					break;
-			}
-
-			samplerId = new SamplerId
-			{
-				Id = _root.Samplers.Count,
-				Root = _root
-			};
-
-			_root.Samplers.Add(sampler);
-
-			return samplerId;
-		}
-
-
-	}
+
+  public partial class GLTFSceneExporter
+  {
+
+
+    private enum IMAGETYPE
+    {
+      RGB,
+      RGBA,
+      R,
+      G,
+      B,
+      A,
+      G_INVERT
+    }
+
+    private enum TextureMapType
+    {
+      Main,
+      Bump,
+      SpecGloss,
+      Emission,
+      MetallicGloss,
+      Light,
+      Occlusion
+    }
+
+    private struct ImageInfo
+    {
+      public Texture2D texture;
+      public TextureMapType textureMapType;
+    }
+
+
+    private void ExportImages(string outputPath)
+    {
+
+      for (int t = 0; t < _imageInfos.Count; ++t)
+      {
+
+        var image = _imageInfos[t].texture;
+        int height = image.height;
+        int width = image.width;
+        Texture2D currentTex = null;
+
+        switch (_imageInfos[t].textureMapType)
+        {
+          case TextureMapType.MetallicGloss:
+            currentTex = ExportMetallicGlossTexture(image, outputPath);
+            break;
+          case TextureMapType.Bump:
+            currentTex = ExportNormalTexture(image, outputPath);
+            break;
+          default:
+            currentTex = ExportTexture(image, outputPath);
+            break;
+        }
+
+        currentTex.name = image.name;
+        ExportCompressed(image, currentTex, outputPath);
+
+        if (Application.isEditor)
+        {
+          GameObject.DestroyImmediate(currentTex);
+        }
+        else
+        {
+          GameObject.Destroy(currentTex);
+        }
+
+      }
+    }
+
+    /// <summary>
+    /// This converts Unity's metallic-gloss texture representation into GLTF's metallic-roughness specifications.
+    /// Unity's metallic-gloss A channel (glossiness) is inverted and goes into GLTF's metallic-roughness G channel (roughness).
+    /// Unity's metallic-gloss R channel (metallic) goes into GLTF's metallic-roughess B channel.
+    /// </summary>
+    /// <param name="texture">Unity's metallic-gloss texture to be exported</param>
+    /// <param name="outputPath">The location to export the texture</param>
+    private Texture2D ExportMetallicGlossTexture(Texture2D texture, string outputPath)
+    {
+      var destRenderTexture = RenderTexture.GetTemporary(texture.width, texture.height, 0, RenderTextureFormat.ARGB32, RenderTextureReadWrite.Linear);
+
+      Graphics.Blit(texture, destRenderTexture, _metalGlossChannelSwapMaterial);
+
+      var exportTexture = new Texture2D(texture.width, texture.height);
+      exportTexture.ReadPixels(new Rect(0, 0, destRenderTexture.width, destRenderTexture.height), 0, 0);
+      exportTexture.Apply();
+
+      var finalFilenamePath = ConstructImageFilenamePath(texture, outputPath);
+      File.WriteAllBytes(finalFilenamePath, exportTexture.EncodeToPNG());
+
+      RenderTexture.ReleaseTemporary(destRenderTexture);
+      // if (Application.isEditor)
+      // {
+      // 	GameObject.DestroyImmediate(exportTexture);
+      // }
+      // else
+      // {
+      // 	GameObject.Destroy(exportTexture);
+      // }
+      return exportTexture;
+    }
+
+    /// <summary>
+    /// This export's the normal texture. If a texture is marked as a normal map, the values are stored in the A and G channel.
+    /// To output the correct normal texture, the A channel is put into the R channel.
+    /// </summary>
+    /// <param name="texture">Unity's normal texture to be exported</param>
+    /// <param name="outputPath">The location to export the texture</param>
+    private Texture2D ExportNormalTexture(Texture2D texture, string outputPath)
+    {
+      var destRenderTexture = RenderTexture.GetTemporary(texture.width, texture.height, 0, RenderTextureFormat.ARGB32, RenderTextureReadWrite.Linear);
+
+      Graphics.Blit(texture, destRenderTexture, _normalChannelMaterial);
+
+      var exportTexture = new Texture2D(texture.width, texture.height);
+      exportTexture.ReadPixels(new Rect(0, 0, destRenderTexture.width, destRenderTexture.height), 0, 0);
+      exportTexture.Apply();
+
+      var finalFilenamePath = ConstructImageFilenamePath(texture, outputPath);
+      File.WriteAllBytes(finalFilenamePath, exportTexture.EncodeToPNG());
+
+
+      RenderTexture.ReleaseTemporary(destRenderTexture);
+      // if (Application.isEditor)
+      // {
+      // 	GameObject.DestroyImmediate(exportTexture);
+      // }
+      // else
+      // {
+      // 	GameObject.Destroy(exportTexture);
+      // }
+      return exportTexture;
+    }
+
+    public Texture2D ExportTexture(Texture2D texture, string outputPath)
+    {
+      var destRenderTexture = RenderTexture.GetTemporary(texture.width, texture.height, 0, RenderTextureFormat.ARGB32, RenderTextureReadWrite.sRGB);
+
+      Graphics.Blit(texture, destRenderTexture);
+
+      var exportTexture = new Texture2D(texture.width, texture.height);
+      exportTexture.ReadPixels(new Rect(0, 0, destRenderTexture.width, destRenderTexture.height), 0, 0);
+      exportTexture.Apply();
+
+      var finalFilenamePath = ConstructImageFilenamePath(texture, outputPath);
+      File.WriteAllBytes(finalFilenamePath, exportTexture.EncodeToPNG());
+
+      RenderTexture.ReleaseTemporary(destRenderTexture);
+      // if (Application.isEditor)
+      // {
+      // 	GameObject.DestroyImmediate(exportTexture);
+      // }
+      // else
+      // {
+      // 	GameObject.Destroy(exportTexture);
+      // }
+      return exportTexture;
+    }
+
+    private string ConstructImageFilenamePath(Texture2D texture, string outputPath)
+    {
+      var imagePath = _exportOptions.TexturePathRetriever(texture);
+      if (string.IsNullOrEmpty(imagePath))
+      {
+        imagePath = Path.Combine(outputPath, texture.name);
+      }
+
+      var filenamePath = Path.Combine(outputPath, imagePath);
+      if (!ExportFullPath)
+      {
+        filenamePath = outputPath + "/" + texture.name;
+      }
+      var file = new FileInfo(filenamePath);
+      file.Directory.Create();
+      return Path.ChangeExtension(filenamePath, ".png");
+    }
+
+
+    private TextureInfo ExportTextureInfo(Texture texture, TextureMapType textureMapType)
+    {
+      var info = new TextureInfo();
+
+      info.Index = ExportTexture(texture, textureMapType);
+
+      return info;
+    }
+
+    private TextureId ExportTexture(Texture textureObj, TextureMapType textureMapType)
+    {
+      TextureId id = GetTextureId(_root, textureObj);
+      if (id != null)
+      {
+        return id;
+      }
+
+      var texture = new GLTFTexture();
+
+      //If texture name not set give it a unique name using count
+      if (textureObj.name == "")
+      {
+        textureObj.name = (_root.Textures.Count + 1).ToString();
+      }
+
+      if (ExportNames)
+      {
+        texture.Name = textureObj.name;
+      }
+
+      if (_shouldUseInternalBufferForImages)
+      {
+        texture.Source = ExportImageInternalBuffer(textureObj, textureMapType);
+      }
+      else
+      {
+        texture.Source = ExportImage(textureObj, textureMapType);
+      }
+
+			// EXTRA CUSTOM
+			// MMP_compressed_texture
+			// ================
+      GLTFTexturesRegistry reg = GLTFExportSettings.Defaults.info.TexturesRegistry;
+      GLTFExportTextureSettings setting = reg.GetSettings(textureObj as Texture2D);
+      if (setting != null && setting.Compress)
+      {
+
+        JObject extra = texture.Source.Value.Extras as JObject;
+        if (extra == null)
+        {
+          extra = new JObject();
+          texture.Source.Value.Extras = extra;
+        }
+
+        extra.Add(
+          "MMP_compressed_texture",
+          true
+        );
+
+      }
+
+
+
+
+      texture.Sampler = ExportSampler(textureObj);
+
+      _textures.Add(textureObj);
+
+      id = new TextureId
+      {
+        Id = _root.Textures.Count,
+        Root = _root
+      };
+
+      _root.Textures.Add(texture);
+
+      return id;
+    }
+
+    private ImageId ExportImage(Texture texture, TextureMapType texturMapType)
+    {
+      ImageId id = GetImageId(_root, texture);
+      if (id != null)
+      {
+        return id;
+      }
+
+      var image = new GLTFImage();
+
+      if (ExportNames)
+      {
+        image.Name = texture.name;
+      }
+
+      _imageInfos.Add(new ImageInfo
+      {
+        texture = texture as Texture2D,
+        textureMapType = texturMapType
+      });
+
+      var imagePath = _exportOptions.TexturePathRetriever(texture);
+      if (string.IsNullOrEmpty(imagePath))
+      {
+        imagePath = texture.name;
+      }
+
+      var filenamePath = Path.ChangeExtension(imagePath, ".png");
+      if (!ExportFullPath)
+      {
+        filenamePath = Path.ChangeExtension(texture.name, ".png");
+      }
+      image.Uri = Uri.EscapeUriString(filenamePath);
+
+      id = new ImageId
+      {
+        Id = _root.Images.Count,
+        Root = _root
+      };
+
+      _root.Images.Add(image);
+
+      return id;
+    }
+
+    private ImageId ExportImageInternalBuffer(UnityEngine.Texture texture, TextureMapType texturMapType)
+    {
+
+      if (texture == null)
+      {
+        throw new Exception("texture can not be NULL.");
+      }
+
+      var image = new GLTFImage();
+      image.MimeType = "image/png";
+
+      var byteOffset = _bufferWriter.BaseStream.Position;
+
+      {//
+        var destRenderTexture = RenderTexture.GetTemporary(texture.width, texture.height, 24, RenderTextureFormat.ARGB32, RenderTextureReadWrite.sRGB);
+        GL.sRGBWrite = true;
+        switch (texturMapType)
+        {
+          case TextureMapType.MetallicGloss:
+            Graphics.Blit(texture, destRenderTexture, _metalGlossChannelSwapMaterial);
+            break;
+          case TextureMapType.Bump:
+            Graphics.Blit(texture, destRenderTexture, _normalChannelMaterial);
+            break;
+          default:
+            Graphics.Blit(texture, destRenderTexture);
+            break;
+        }
+
+        var exportTexture = new Texture2D(texture.width, texture.height, TextureFormat.ARGB32, false);
+        exportTexture.ReadPixels(new Rect(0, 0, destRenderTexture.width, destRenderTexture.height), 0, 0);
+        exportTexture.Apply();
+
+        var pngImageData = exportTexture.EncodeToPNG();
+        _bufferWriter.Write(pngImageData);
+
+        RenderTexture.ReleaseTemporary(destRenderTexture);
+
+        GL.sRGBWrite = false;
+        if (Application.isEditor)
+        {
+          UnityEngine.Object.DestroyImmediate(exportTexture);
+        }
+        else
+        {
+          UnityEngine.Object.Destroy(exportTexture);
+        }
+      }
+
+      var byteLength = _bufferWriter.BaseStream.Position - byteOffset;
+
+      byteLength = AppendToBufferMultiplyOf4(byteOffset, byteLength);
+
+      image.BufferView = ExportBufferView((uint)byteOffset, (uint)byteLength);
+
+
+      var id = new ImageId
+      {
+        Id = _root.Images.Count,
+        Root = _root
+      };
+      _root.Images.Add(image);
+
+      return id;
+    }
+    private SamplerId ExportSampler(Texture texture)
+    {
+      var samplerId = GetSamplerId(_root, texture);
+      if (samplerId != null)
+        return samplerId;
+
+      var sampler = new Sampler();
+
+      switch (texture.wrapMode)
+      {
+        case TextureWrapMode.Clamp:
+          sampler.WrapS = WrapMode.ClampToEdge;
+          sampler.WrapT = WrapMode.ClampToEdge;
+          break;
+        case TextureWrapMode.Repeat:
+          sampler.WrapS = WrapMode.Repeat;
+          sampler.WrapT = WrapMode.Repeat;
+          break;
+        case TextureWrapMode.Mirror:
+          sampler.WrapS = WrapMode.MirroredRepeat;
+          sampler.WrapT = WrapMode.MirroredRepeat;
+          break;
+        default:
+          Debug.LogWarning("Unsupported Texture.wrapMode: " + texture.wrapMode);
+          sampler.WrapS = WrapMode.Repeat;
+          sampler.WrapT = WrapMode.Repeat;
+          break;
+      }
+
+      switch (texture.filterMode)
+      {
+        case FilterMode.Point:
+          sampler.MinFilter = MinFilterMode.NearestMipmapNearest;
+          sampler.MagFilter = MagFilterMode.Nearest;
+          break;
+        case FilterMode.Bilinear:
+          sampler.MinFilter = MinFilterMode.LinearMipmapNearest;
+          sampler.MagFilter = MagFilterMode.Linear;
+          break;
+        case FilterMode.Trilinear:
+          sampler.MinFilter = MinFilterMode.LinearMipmapLinear;
+          sampler.MagFilter = MagFilterMode.Linear;
+          break;
+        default:
+          Debug.LogWarning("Unsupported Texture.filterMode: " + texture.filterMode);
+          sampler.MinFilter = MinFilterMode.LinearMipmapLinear;
+          sampler.MagFilter = MagFilterMode.Linear;
+          break;
+      }
+
+      samplerId = new SamplerId
+      {
+        Id = _root.Samplers.Count,
+        Root = _root
+      };
+
+      _root.Samplers.Add(sampler);
+
+      return samplerId;
+    }
+
+
+  }
 }

--- a/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/Lib/KTX.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/Lib/KTX.cs
@@ -1,0 +1,254 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace UnityGLTF
+{
+  public class KTX
+  {
+
+    static byte[] KTX_MAGIC = { 0xAB, 0x4B, 0x54, 0x58, 0x20, 0x31, 0x31, 0xBB, 0x0D, 0x0A, 0x1A, 0x0A };
+
+    private static Dictionary<TextureFormat, int> _GlInternal = new Dictionary<TextureFormat, int>
+    {
+      {TextureFormat.RGB24, 0x8051},
+      {TextureFormat.RGBA32, 0x8058},
+      {TextureFormat.DXT1, 0x83F0},
+      {TextureFormat.DXT5, 0x83F3},
+      {TextureFormat.PVRTC_RGB2, 0x8C01},
+      {TextureFormat.PVRTC_RGBA2, 0x8C03},
+      {TextureFormat.PVRTC_RGB4, 0x8C00},
+      {TextureFormat.PVRTC_RGBA4, 0x8C02},
+      {TextureFormat.ETC_RGB4, 0x8D64},
+      {TextureFormat.ETC2_RGBA1, 0x9275},
+      {TextureFormat.ASTC_4x4, 0x93B0},
+      {TextureFormat.ASTC_5x5, 0x93B2},
+      {TextureFormat.ASTC_6x6, 0x93B4},
+      {TextureFormat.ASTC_8x8, 0x93B7},
+      {TextureFormat.ASTC_10x10, 0x93BB},
+    };
+
+
+    // Get bytes per pixels
+    public static float GetBPP(TextureFormat format)
+    {
+
+      switch (format)
+      {
+        case TextureFormat.DXT5:
+          return 1f;
+        case TextureFormat.PVRTC_RGB2:
+        case TextureFormat.PVRTC_RGBA2:
+          return 0.25f;
+        default:
+          return 0.5f;
+      }
+
+    }
+
+
+    public static int GetBytesBlockSize(TextureFormat fmt)
+    {
+
+      switch (fmt)
+      {
+
+        // TODO
+        // case TextureFormat.ASTC_4x4:
+        // case TextureFormat.ASTC_5x5:
+        // case TextureFormat.ASTC_6x6:
+        // case TextureFormat.ASTC_8x8:
+        // case TextureFormat.ASTC_10x10:
+        //   return 128;
+
+        case TextureFormat.PVRTC_RGBA4:
+        case TextureFormat.PVRTC_RGB4:
+        case TextureFormat.PVRTC_RGB2:
+        case TextureFormat.PVRTC_RGBA2:
+          return 32;
+
+        case TextureFormat.DXT5:
+          return 16;
+
+        case TextureFormat.DXT1:
+        case TextureFormat.ETC2_RGBA1:
+        case TextureFormat.ETC_RGB4:
+          return 8;
+
+        default:
+          return 8;
+
+      }
+
+    }
+
+
+    public static Dictionary<TextureFormat, string> Exts = new Dictionary<TextureFormat, string>()
+    {
+      {TextureFormat.RGB24, ".jpg"},
+      {TextureFormat.RGBA32, ".png"},
+      {TextureFormat.DXT1, ".dxt"},
+      {TextureFormat.DXT5, ".dxt5"},
+      {TextureFormat.PVRTC_RGB2, ".pvr2bpp"},
+      {TextureFormat.PVRTC_RGBA2, ".pvr2bpp"},
+      {TextureFormat.PVRTC_RGB4, ".pvr"},
+      {TextureFormat.PVRTC_RGBA4, ".pvr"},
+      {TextureFormat.ETC_RGB4, ".etc"},
+      {TextureFormat.ETC2_RGBA1, ".etc2"},
+      {TextureFormat.ASTC_4x4, ".astc"},
+      {TextureFormat.ASTC_5x5, ".astc"},
+      {TextureFormat.ASTC_6x6, ".astc"},
+      {TextureFormat.ASTC_8x8, ".astc"},
+      {TextureFormat.ASTC_10x10, ".astc"}
+    };
+
+
+    public static string GetExt(TextureFormat format)
+    {
+      string output;
+      Exts.TryGetValue(format, out output);
+      output += ".ktx";
+      return output;
+    }
+
+
+    public static byte[] Encode(Texture2D texture, TextureFormat format)
+    {
+
+      byte[] textureData = texture.GetRawTextureData();
+
+      int glInternalFormat;
+      _GlInternal.TryGetValue(format, out glInternalFormat);
+
+      // texture info
+      int mipcount = texture.mipmapCount;
+      int width = texture.width;
+      int height = texture.height;
+      int tlen = (textureData.Length & ~3);
+
+      // setup data
+      int blockSize = GetBytesBlockSize(format);
+      int int32len = 4;
+      int dlen = 64 + tlen + mipcount * 4;
+      byte[] data = new byte[dlen];
+
+      int ptr = 0;
+      int size = 0;
+
+      // MAGIC
+      byte[] value = KTX_MAGIC;
+      size = KTX_MAGIC.Length;
+      Array.Copy(value, 0, data, ptr, value.Length);
+      ptr += size;
+
+      // endianness
+      value = BitConverter.GetBytes(0x04030201);
+      size = value.Length;
+      Array.Copy(value, 0, data, ptr, value.Length);
+      ptr += size;
+
+      // glType
+      value = new byte[4];
+      Array.Copy(value, 0, data, ptr, value.Length);
+      ptr += value.Length;
+
+      // glTypeSize
+      value = BitConverter.GetBytes((uint)1);
+      Array.Copy(value, 0, data, ptr, int32len);
+      ptr += value.Length;
+
+      // glFormat
+      value = new byte[4];
+      Array.Copy(value, 0, data, ptr, value.Length);
+      ptr += value.Length;
+
+      // glInternalFormat
+      // value = BitConverter.GetBytes((uint)setting.info.GetGlInternal(exportTexture.format));
+      value = BitConverter.GetBytes((uint)glInternalFormat);
+      Array.Copy(value, 0, data, ptr, value.Length);
+      ptr += value.Length;
+
+      // glBaseInternalFormat
+      // RGB	0x1907	 
+      // RGBA	0x1908
+      value = BitConverter.GetBytes((uint)0x1907);
+      Array.Copy(value, 0, data, ptr, int32len);
+      ptr += int32len;
+
+      // pixelWidth
+      value = BitConverter.GetBytes((uint)width);
+      Array.Copy(value, 0, data, ptr, int32len);
+      ptr += int32len;
+
+      // pixelHeight
+      value = BitConverter.GetBytes((uint)height);
+      Array.Copy(value, 0, data, ptr, int32len);
+      ptr += int32len;
+
+      // depth
+      // TODO
+      value = new byte[4];
+      Array.Copy(value, 0, data, ptr, int32len);
+      ptr += int32len;
+
+
+      // numberOfArrayElements
+      // TODO
+      value = BitConverter.GetBytes((uint)1);
+      Array.Copy(value, 0, data, ptr, int32len);
+      ptr += int32len;
+
+
+      // numberOfFace
+      // TODO
+      value = BitConverter.GetBytes((uint)1);
+      Array.Copy(value, 0, data, ptr, int32len);
+      ptr += int32len;
+
+
+      // numberOfMipmapLevels
+      value = BitConverter.GetBytes((uint)mipcount);
+      Array.Copy(value, 0, data, ptr, int32len);
+      ptr += int32len;
+
+
+      // bytesOfKeyValueData
+      value = new byte[4];
+      Array.Copy(value, 0, data, ptr, int32len);
+      ptr += int32len;
+
+
+      // textureData
+      int w = width;
+      int h = height;
+      // int isize = (w * h) / 2;
+      int isize = (int)((float)(w * h) * GetBPP(format));
+      isize = Mathf.Max(blockSize, isize);
+
+      int texptr = 0;
+      for (int i = 0; i < mipcount; i++)
+      {
+
+        byte[] bisize = BitConverter.GetBytes((uint)isize);
+        // imageSize
+        Array.Copy(bisize, 0, data, ptr, int32len);
+        ptr += int32len;
+        // data
+        Array.Copy(textureData, texptr, data, ptr, isize);
+        texptr += isize;
+        ptr += isize & ~3;
+
+        w = w >> 1;
+        h = h >> 1;
+        isize = (int)((float)(w * h) * GetBPP(format));
+        isize = Mathf.Max(blockSize, isize);
+
+      }
+
+      return data;
+
+    }
+
+  }
+
+}

--- a/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/Settings/GLTFExportSettings.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/Settings/GLTFExportSettings.cs
@@ -7,7 +7,8 @@ using UnityEditor;
 
 
 [CustomEditor(typeof(GLTFExportSettings))]
-internal class SettingsEditor : UnityEditor.Editor {
+internal class SettingsEditor : UnityEditor.Editor
+{
   Vector2 scrollPos = Vector2.zero;
   const float LabelWidth = 150;
   const float SelectableLabelMinWidth = 90;
@@ -19,42 +20,46 @@ internal class SettingsEditor : UnityEditor.Editor {
 
   private string[] exportFormatOptions = new string[] { "GLB", "GLTF" };
 
-  public List<SerializedProperty> GetSections( SerializedProperty infoProperty ){
+  public List<SerializedProperty> GetSections(SerializedProperty infoProperty)
+  {
 
     infoProperty.Next(true);
     var sectionProperty = infoProperty.Copy();
 
     var res = new List<SerializedProperty>();
-    do {
-      res.Add( sectionProperty.Copy() );
-    } while( sectionProperty.Next(false) );
+    do
+    {
+      res.Add(sectionProperty.Copy());
+    } while (sectionProperty.Next(false));
     return res;
   }
 
-  public override void OnInspectorGUI() {
-    
+  public override void OnInspectorGUI()
+  {
+
     serializedObject.Update();
-    
+
     GLTFExportSettings exportSettings = (GLTFExportSettings)target;
     GLTFExportSettingsData data = exportSettings.info;
     SerializedProperty infoProperty = serializedObject.FindProperty("m_info");
-    
-    var sections = GetSections( infoProperty );
+
+    var sections = GetSections(infoProperty);
 
     // Increasing the label width so that none of the text gets cut off
     EditorGUIUtility.labelWidth = LabelWidth;
 
-    GUILayout.BeginVertical ();
+    GUILayout.BeginVertical();
     var w = EditorGUIUtility.currentViewWidth;
     foreach (var section in sections)
     {
-      section.isExpanded = true;
-      var h = EditorGUI.GetPropertyHeight( section, true );
-      var myRect = GUILayoutUtility.GetRect(20, h+10);
+      // Debug.Log(section.name);
+      // section.isExpanded = true;
+      var h = EditorGUI.GetPropertyHeight(section, true);
+      var myRect = GUILayoutUtility.GetRect(20, h + 10);
       EditorGUI.PropertyField(myRect, section, true);
     }
 
-    GUILayout.EndVertical ();
+    GUILayout.EndVertical();
 
     serializedObject.ApplyModifiedProperties();
   }
@@ -63,7 +68,8 @@ internal class SettingsEditor : UnityEditor.Editor {
 #endif
 
 
-public class GLTFExportSettings : SerializedSettings<GLTFExportSettingsData> {
+public class GLTFExportSettings : SerializedSettings<GLTFExportSettingsData>
+{
 
   // [SerializeField]
   // public SettingsSerializable directSettings;
@@ -73,24 +79,37 @@ public class GLTFExportSettings : SerializedSettings<GLTFExportSettingsData> {
 
   private static GLTFExportSettings m_defaults = null;
 
-  public static GLTFExportSettings Defaults {
-    get {
-      if (m_defaults == null) {
-        m_defaults = LoadDefaults ();
+  public static GLTFExportSettings Defaults
+  {
+    get
+    {
+      if (m_defaults == null)
+      {
+        m_defaults = LoadDefaults();
       }
       return m_defaults;
     }
   }
 
-  private static GLTFExportSettings LoadDefaults() {
+  private static GLTFExportSettings LoadDefaults()
+  {
     GLTFExportSettings settings;
 
-    if (!EditorBuildSettings.TryGetConfigObject (k_ConfigObjectName, out settings)) {
-      settings = ScriptableObject.CreateInstance<GLTFExportSettings> ();
-      AssetDatabase.CreateAsset (settings, k_SettingsPath);
-      EditorBuildSettings.AddConfigObject (k_ConfigObjectName, settings, true);
+    if (!EditorBuildSettings.TryGetConfigObject(k_ConfigObjectName, out settings))
+    {
+      settings = ScriptableObject.CreateInstance<GLTFExportSettings>();
+      AssetDatabase.CreateAsset(settings, k_SettingsPath);
+      EditorBuildSettings.AddConfigObject(k_ConfigObjectName, settings, true);
     }
     return settings;
+  }
+
+  [MenuItem("GLTF/Generate Settings")]
+  private static void CreateSettings()
+  {
+
+    Debug.Log(Defaults);
+
   }
 
 }

--- a/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/Settings/GLTFExportSettingsData.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/Settings/GLTFExportSettingsData.cs
@@ -1,21 +1,50 @@
 
 
+using System.Collections.Generic;
 using UnityEngine;
 
+public class TextureMap : Dictionary<string, GLTFExportTextureSettings> { }
+
 [System.Serializable]
-public class GLTFExportSettingsData {
+public class TextureSettingsLink
+{
+  public string guid;
+  public GLTFExportTextureSettings settings;
+}
+
+
+
+[System.Serializable]
+public class GLTFExportSettingsData
+{
 
   [SerializeField]
   private GLTFExportMeshSettingsSerializable m_meshSettings;
-  public GLTFExportMeshSettingsSerializable MeshSettings {
+  public GLTFExportMeshSettingsSerializable MeshSettings
+  {
     get { return m_meshSettings; }
   }
 
   [SerializeField]
   private GLTFExportAnimationsSettingsSerializable m_animationSettings;
-  public GLTFExportAnimationsSettingsSerializable AnimationsSettings {
+  public GLTFExportAnimationsSettingsSerializable AnimationsSettings
+  {
     get { return m_animationSettings; }
   }
-  
+
+  [SerializeField]
+  public GLTFExportTextureSettings m_textureSettingsDefault;
+  public GLTFExportTextureSettings TextureSettingsDefaults
+  {
+    get { return m_textureSettingsDefault; }
+  }
+
+  [SerializeField]
+  public GLTFTexturesRegistry m_texRegistry;
+  public GLTFTexturesRegistry TexturesRegistry
+  {
+    get { return m_texRegistry; }
+  }
+
 }
 

--- a/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/Settings/GLTFExportTextureSettings.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/Settings/GLTFExportTextureSettings.cs
@@ -1,41 +1,31 @@
 ﻿using System;
+using System.Collections.Generic;
 using UnityEngine;
 
 
 [System.Serializable]
-public class GLTFExportTextureSettingsSerializable
+public class GLTFExportTextureSettings
 {
 
-  
-  public enum LODExportType {
-    Highest = 0,
-    Lowest  = 1,
+  // TODO
+  public enum Resize
+  {
+    None = 0,
+    Quart = 1,
+    Half = 2
   }
 
-  [Flags]
-  public enum ExportedAttributes {
-    Position = 1<<0,
-    Normal = 1<<1,
-    Tangent = 1<<2,
-    UV0 = 1<<3,
-    UV1 = 1<<4,
-    UV2 = 1<<5,
-    UV3 = 1<<6,
-  }
-
-  private const ExportedAttributes ALL_ATTRIBUTES = ExportedAttributes.UV3 | (ExportedAttributes.UV3-1);
-
-
-
+  // TODO
+  [HideInInspector]
   [SerializeField]
-  public bool exportMeshes;
+  public Resize resize = Resize.None;
 
+  // TODO
+  [HideInInspector]
   [SerializeField]
-  public ExportedAttributes attributes = ALL_ATTRIBUTES;
+  public bool flipY;
 
-  [SerializeField]
-  public LODExportType lod;
+  public bool Compress = false;
+  public bool GenerateMipMap = false;
 
 }
-
-public class GLTFExportTextureSettings : SerializedSettings<GLTFExportMeshSettingsSerializable>{}

--- a/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/Settings/GLTFTextureSettingsBinding.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/Settings/GLTFTextureSettingsBinding.cs
@@ -1,0 +1,19 @@
+
+using UnityEngine;
+
+[System.Serializable]
+public class GLTFTextureSettingsBinding : ScriptableObject
+{
+
+  [SerializeField]
+  public Texture2D texture;
+  [SerializeField]
+  public GLTFExportTextureSettings settings;
+
+  public void Attach(Texture2D tex, GLTFExportTextureSettings set)
+  {
+    texture = tex;
+    settings = set;
+  }
+
+}

--- a/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/Settings/GLTFTexturesRegistry.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/Settings/GLTFTexturesRegistry.cs
@@ -1,0 +1,114 @@
+
+using System.Collections.Generic;
+using UnityEngine;
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
+
+
+
+[System.Serializable]
+public class GLTFTexturesRegistry
+{
+
+  [SerializeField]
+  private List<GLTFTextureSettingsBinding> m_bindings;
+  public List<GLTFTextureSettingsBinding> Bindings
+  {
+    get
+    {
+      if (m_bindings == null)
+      {
+        m_bindings = new List<GLTFTextureSettingsBinding>();
+      }
+      return m_bindings;
+    }
+  }
+
+
+#if UNITY_EDITOR
+
+  private string GetGUID(Object obj)
+  {
+    string guid;
+    long localid;
+    AssetDatabase.TryGetGUIDAndLocalFileIdentifier(obj, out guid, out localid);
+    return guid;
+  }
+
+  public GLTFTextureSettingsBinding GetBinding(Texture2D tex)
+  {
+    GLTFTextureSettingsBinding binding = null;
+    for (var i = 0; i < Bindings.Count; i++)
+    {
+      if (m_bindings[i].texture == tex)
+      {
+        binding = m_bindings[i];
+      }
+    }
+    return binding;
+  }
+
+
+  public GLTFExportTextureSettings GetSettings(Texture2D texture)
+  {
+
+    GLTFTextureSettingsBinding bin = GetBinding(texture);
+    if (bin == null)
+      return null;
+    return bin.settings;
+
+  }
+
+
+  public GLTFExportTextureSettings CreateSettings(Texture2D texture)
+  {
+
+    GLTFTextureSettingsBinding binding = GetBinding(texture);
+    if (binding != null)
+    {
+      Debug.LogWarning("Texture " + texture.name + " already has settings");
+      return null;
+    }
+
+    binding = ScriptableObject.CreateInstance<GLTFTextureSettingsBinding>();
+    binding.hideFlags = HideFlags.None;
+
+    GLTFExportTextureSettings settings = new GLTFExportTextureSettings();
+    binding.Attach(texture, settings);
+    m_bindings.Add(binding);
+
+    binding.name = texture.name + "_settings_" + GetGUID(texture);
+
+    AssetDatabase.AddObjectToAsset(binding, GLTFExportSettings.Defaults);
+
+    EditorUtility.SetDirty(binding);
+    EditorUtility.SetDirty(GLTFExportSettings.Defaults);
+    AssetDatabase.SaveAssets();
+
+    return settings;
+
+  }
+
+
+  public void RemoveSettings(Texture2D texture)
+  {
+
+    GLTFTextureSettingsBinding binding = GetBinding(texture);
+
+    if (binding == null)
+      return;
+
+    AssetDatabase.RemoveObjectFromAsset(binding);
+    binding.settings = null;
+    m_bindings.Remove(binding);
+    binding = null;
+
+    EditorUtility.SetDirty(GLTFExportSettings.Defaults);
+    AssetDatabase.SaveAssets();
+
+  }
+
+#endif
+
+}


### PR DESCRIPTION
**GLTFExportSettings**
Add texture settings handling
Add texture compression settings inside editor to target webgl implementation.

In GLTFInspector ( GLTF/AssetsInspector ) textures are raised from selected objects.
Adding a settings add a definition inside `GltfExportSettings`

Added `GLTF/GenerateSettings` in top bar if `GltfExportSettings` doesn't exist.

Current supported compressed format are:
-  PVRTC_RGB4
- DXT1
- ETC_RGB4

Added KTX file encoder.

Added `MMP_compressed_texture` custom extra to Image element :
```
"images": [
    ...
    {
      "uri": "Assets/Models/Apple/Red_Apple_Albedo.png",
      "name": "Red_Apple_Albedo",
      "extras": {
        "MMP_compressed_texture": true
      }
    }
   ...
]
```

**TODO:**

- Test alpha implementation
- Fix end block padding in KTX encoder for PVRTC_RGB2, DXT5, ASTC.